### PR TITLE
replace netcat with socat for liveness probe/metrics

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG GPG_KEY=C823E3E5B12AF29C67F81976F5CECB3CB5E9BD2D
 ARG ZK_DIST=zookeeper-3.4.10
 RUN set -x \
     && apt-get update \
-    && apt-get install -y openjdk-8-jre-headless wget netcat-openbsd \
+    && apt-get install -y openjdk-8-jre-headless wget socat \
 	&& wget -q "http://www.apache.org/dist/zookeeper/$ZK_DIST/$ZK_DIST.tar.gz" \
     && wget -q "http://www.apache.org/dist/zookeeper/$ZK_DIST/$ZK_DIST.tar.gz.asc" \
     && export GNUPGHOME="$(mktemp -d)" \

--- a/docker/scripts/zookeeper-metrics
+++ b/docker/scripts/zookeeper-metrics
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo mntr | nc localhost $1 >& 1
+echo mntr | socat STDIO TCP:localhost:$1 >& 1

--- a/docker/scripts/zookeeper-ready
+++ b/docker/scripts/zookeeper-ready
@@ -17,7 +17,7 @@
 # is health. The $? variable will be set to 0 if server responds that it is 
 # healthy, or 1 if the server fails to respond.
 
-OK=$(echo ruok | nc 127.0.0.1 $1)
+OK=$(echo ruok | socat STDIO TCP:127.0.0.1:$1)
 if [ "$OK" == "imok" ]; then
 	exit 0
 else


### PR DESCRIPTION
We've had an issue on Google Kubernetes Engine, on a node with
kernel version 4.14.138+, where liveness probes would regularly fail
some percentage of the time.

We've traced the problem down to the `poll()` system call sometimes
failing in the `nc` command used in the liveness probe, whereupon
`nc` returns an empty response, despite the TCP connection from
Zookeeper clearly sending back an `imok`.

Netcat uses `select()`, `poll()`, `read()`, where `poll()` sometimes
throws an error because Zookeeper has closed the TCP connection.
Socat uses `select()`, `read()`, which works here.